### PR TITLE
Implement filesystem watch support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4282,6 +4282,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
 name = "num-integer"
 version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7088,13 +7094,14 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.30"
+version = "0.3.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4a34ab300f2dee6e562c10a046fc05e358b29f9bf92277f30c3c8d82275f6f5"
+checksum = "ef89ece63debf11bc32d1ed8d078ac870cbeb44da02afb02a9ff135ae7ca0582"
 dependencies = [
  "deranged",
  "itoa 1.0.9",
  "libc",
+ "num-conv",
  "num_threads",
  "powerfmt",
  "serde",
@@ -7110,10 +7117,11 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.15"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ad70d68dba9e1f8aceda7aa6711965dfec1cac869f311a51bd08b3a2ccbce20"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
+ "num-conv",
  "time-core",
 ]
 

--- a/server/bleep/src/background.rs
+++ b/server/bleep/src/background.rs
@@ -271,11 +271,18 @@ impl BoundSyncQueue {
     /// Block until the repository sync & index process is complete.
     ///
     /// Returns the new status.
-    pub(crate) async fn block_until_synced(self, reporef: RepoRef) -> anyhow::Result<SyncStatus> {
+    pub(crate) async fn block_until_synced(
+        self,
+        reporef: RepoRef,
+        changed: Option<Vec<PathBuf>>,
+    ) -> anyhow::Result<SyncStatus> {
         let Self(app) = &self;
         let jobs = &app.sync_queue;
 
-        let handle = SyncConfig::new(app, reporef).into_handle().await;
+        let handle = SyncConfig::new(app, reporef)
+            .changed(changed)
+            .into_handle()
+            .await;
         let finished = handle.notify_done();
 
         jobs.queue.push(handle).await;

--- a/server/bleep/src/background/sync.rs
+++ b/server/bleep/src/background/sync.rs
@@ -24,6 +24,7 @@ pub struct SyncHandle {
     pub(crate) file_cache: FileCache,
     pub(crate) app: Application,
     pub(crate) shallow_config: gix::remote::fetch::Shallow,
+    pub(crate) changed: Option<Vec<PathBuf>>,
     shallow: bool,
     exited: flume::Sender<SyncStatus>,
     exit_signal: flume::Receiver<SyncStatus>,
@@ -103,6 +104,7 @@ pub struct SyncConfig {
     reporef: RepoRef,
     filter_updates: Option<FilterUpdate>,
     shallow: bool,
+    changed: Option<Vec<PathBuf>>,
 }
 
 impl SyncConfig {
@@ -112,11 +114,17 @@ impl SyncConfig {
             reporef,
             filter_updates: None,
             shallow: false,
+            changed: None,
         }
     }
 
     pub fn shallow(mut self, shallow: bool) -> Self {
         self.shallow = shallow;
+        self
+    }
+
+    pub fn changed(mut self, changed: Option<Vec<PathBuf>>) -> Self {
+        self.changed = changed;
         self
     }
 
@@ -132,6 +140,7 @@ impl SyncHandle {
             reporef,
             filter_updates,
             shallow,
+            changed,
             ..
         } = config;
         let status = app.sync_queue.broadcast();
@@ -211,6 +220,7 @@ impl SyncHandle {
             shallow,
             pipes,
             filter_updates,
+            changed,
             exited,
             exit_signal,
         };

--- a/server/bleep/src/config.rs
+++ b/server/bleep/src/config.rs
@@ -44,6 +44,11 @@ pub struct Configuration {
     /// Disable system-native notification backends to detect new git commits immediately.
     pub disable_fsevents: bool,
 
+    #[clap(long, default_value_t = default_enable_fs_watch())]
+    #[serde(default = "default_enable_fs_watch")]
+    /// Enable filesystem watching for local repositories.
+    pub enable_fs_watch: bool,
+
     #[clap(long, default_value_t = false)]
     #[serde(default)]
     /// Avoid writing logs to files.
@@ -185,6 +190,8 @@ impl Configuration {
 
             disable_fsevents: b.disable_fsevents | a.disable_fsevents,
 
+            enable_fs_watch: b.enable_fs_watch & a.enable_fs_watch,
+
             disable_log_write: b.disable_log_write | a.disable_log_write,
 
             buffer_size: right_if_default!(b.buffer_size, a.buffer_size, default_buffer_size()),
@@ -307,6 +314,10 @@ fn default_qdrant_url() -> String {
 
 fn default_max_chunk_tokens() -> usize {
     256
+}
+
+const fn default_enable_fs_watch() -> bool {
+    true
 }
 
 fn interactive_batch_size() -> NonZeroUsize {

--- a/server/bleep/src/indexes/file.rs
+++ b/server/bleep/src/indexes/file.rs
@@ -102,6 +102,7 @@ impl Indexable for File {
             ref file_cache,
             ref pipes,
             ref app,
+            ref changed,
             ..
         }: &SyncHandle,
         repo: &Repository,
@@ -195,7 +196,11 @@ impl Indexable for File {
                 })
                 .unwrap_or_else(|| "HEAD".to_owned());
 
-            let walker = FileWalker::index_directory(&repo.disk_path, branch);
+            let walker = if let Some(paths) = changed.clone() {
+                FileWalker::from_paths(&repo.disk_path, paths)
+            } else {
+                FileWalker::index_directory(&repo.disk_path, branch)
+            };
             let count = walker.len();
             walker.for_each(pipes, file_worker(count));
         };

--- a/server/bleep/src/periodic/remotes.rs
+++ b/server/bleep/src/periodic/remotes.rs
@@ -1,5 +1,7 @@
 use std::{
+    collections::HashSet,
     ops::Not,
+    path::PathBuf,
     sync::Arc,
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
@@ -130,6 +132,7 @@ pub(crate) async fn check_repo_updates(app: Application) {
 async fn periodic_repo_poll(app: Application, reporef: RepoRef) -> Option<()> {
     debug!(?reporef, "monitoring repo for changes");
     let mut poller = Poller::start(&app, &reporef)?;
+    let mut changed: Option<Vec<PathBuf>> = None;
 
     loop {
         use SyncStatus::*;
@@ -155,7 +158,11 @@ async fn periodic_repo_poll(app: Application, reporef: RepoRef) -> Option<()> {
         }
 
         debug!("starting sync");
-        if let Err(err) = app.write_index().block_until_synced(reporef.clone()).await {
+        if let Err(err) = app
+            .write_index()
+            .block_until_synced(reporef.clone(), changed.take())
+            .await
+        {
             error!(?err, ?reporef, "failed to sync & index repo");
             return None;
         }
@@ -187,17 +194,24 @@ async fn periodic_repo_poll(app: Application, reporef: RepoRef) -> Option<()> {
             )
         }
 
-        match tokio::time::timeout(poller.jittery_interval(), poller.git_change()).await {
-            Ok(_) => debug!(?reporef, "git changes triggered reindexing"),
-            Err(_) => debug!(?reporef, "timeout; reindexing"),
-        }
+        changed = match tokio::time::timeout(poller.jittery_interval(), poller.git_change()).await {
+            Ok(paths) => {
+                debug!(?reporef, "git changes triggered reindexing");
+                Some(paths.into_iter().collect())
+            }
+            Err(_) => {
+                debug!(?reporef, "timeout; reindexing");
+                None
+            }
+        };
     }
 }
 
 struct Poller {
     poll_interval_index: usize,
     minimum_interval_index: usize,
-    git_events: flume::Receiver<()>,
+    changed: HashSet<PathBuf>,
+    git_events: flume::Receiver<Vec<PathBuf>>,
     debouncer: Option<Debouncer<RecommendedWatcher>>,
 }
 
@@ -209,7 +223,10 @@ impl Poller {
         let (tx, rx) = flume::bounded(10);
 
         let mut _debouncer = None;
-        if !app.config.disable_fsevents && reporef.backend() == Backend::Local {
+        if app.config.enable_fs_watch
+            && !app.config.disable_fsevents
+            && reporef.backend() == Backend::Local
+        {
             let disk_path = app.repo_pool.read(reporef, |_, v| v.disk_path.clone())?;
 
             let mut debouncer = debounced_events(tx);
@@ -232,6 +249,7 @@ impl Poller {
         Some(Self {
             poll_interval_index,
             minimum_interval_index,
+            changed: HashSet::new(),
             debouncer: _debouncer,
             git_events: rx,
         })
@@ -263,14 +281,19 @@ impl Poller {
         poll_interval + Duration::from_secs(jitter)
     }
 
-    async fn git_change(&mut self) {
+    async fn git_change(&mut self) -> HashSet<PathBuf> {
         if self.debouncer.is_some() {
-            _ = self.git_events.recv_async().await;
-            _ = self.git_events.drain().collect::<Vec<_>>();
-        } else {
-            loop {
-                futures::pending!()
+            if let Ok(paths) = self.git_events.recv_async().await {
+                self.changed.extend(paths);
             }
+            while let Ok(paths) = self.git_events.try_recv() {
+                self.changed.extend(paths);
+            }
+            return std::mem::take(&mut self.changed);
+        }
+
+        loop {
+            futures::pending!()
         }
     }
 }
@@ -285,13 +308,14 @@ fn check_repo(app: &Application, reporef: &RepoRef) -> Option<(u64, i64, SyncSta
     })
 }
 
-fn debounced_events(tx: flume::Sender<()>) -> Debouncer<RecommendedWatcher> {
+fn debounced_events(tx: flume::Sender<Vec<PathBuf>>) -> Debouncer<RecommendedWatcher> {
     new_debouncer_opt(
         Duration::from_secs(5),
         None,
         move |event: DebounceEventResult| match event {
             Ok(events) if events.is_empty().not() => {
-                if let Err(e) = tx.send(()) {
+                let paths = events.into_iter().map(|e| e.path).collect();
+                if let Err(e) = tx.send(paths) {
                     error!("{e}");
                 }
             }

--- a/server/bleep/src/repo/iterator/fs.rs
+++ b/server/bleep/src/repo/iterator/fs.rs
@@ -35,6 +35,30 @@ impl FileWalker {
 
         Self { file_list, branch }
     }
+
+    pub fn from_paths(root: &Path, paths: Vec<PathBuf>) -> Self {
+        use std::collections::HashSet;
+
+        let mut unique = HashSet::new();
+        let mut file_list = vec![];
+        for path in paths {
+            let full = if path.is_absolute() {
+                path
+            } else {
+                root.join(path)
+            };
+            if let Ok(canon) = crate::canonicalize(full) {
+                if unique.insert(canon.clone()) {
+                    file_list.push(canon);
+                }
+            }
+        }
+
+        Self {
+            file_list,
+            branch: "HEAD".into(),
+        }
+    }
 }
 
 impl FileSource for FileWalker {
@@ -76,5 +100,21 @@ impl FileSource for FileWalker {
                 .take_any_while(|_| !pipes.is_cancelled())
                 .for_each(iterator);
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn from_paths_collects_files() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("a.txt");
+        std::fs::write(&file, "a").unwrap();
+
+        let walker = FileWalker::from_paths(dir.path(), vec![file.clone()]);
+        assert_eq!(walker.len(), 1);
     }
 }


### PR DESCRIPTION
## Summary
- add enable_fs_watch config flag
- watch filesystem for changed paths
- pass changed paths to sync jobs
- support FileWalker::from_paths
- unit test for FileWalker::from_paths

## Testing
- `cargo test -p bleep --tests --quiet` *(fails: could not compile due to Rust toolchain or dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688c7921b7808326918e67102fc59cb1